### PR TITLE
优化合成样板提供器以修复大规模合成卡顿问题

### DIFF
--- a/src/main/java/reobf/proghatches/gt/metatileentity/ProgrammingCircuitProvider.java
+++ b/src/main/java/reobf/proghatches/gt/metatileentity/ProgrammingCircuitProvider.java
@@ -152,12 +152,10 @@ public class ProgrammingCircuitProvider extends MTEHatch implements IAddUIWidget
         } catch (GridAccessException e) {
 
         }
-        ItemStack circuitItem = (patternDetails.getOutput(
-            table,
-            this.getBaseMetaTileEntity()
-                .getWorld()));
-
-        ret.add(AEItemStack.create(circuitItem));
+        IAEItemStack[] outputs = patternDetails.getOutputs();
+        if (outputs != null && outputs.length > 0) {
+            ret.add(outputs[0]);
+        }
         return true;
     }
 
@@ -373,6 +371,9 @@ public class ProgrammingCircuitProvider extends MTEHatch implements IAddUIWidget
         final public ItemStack out;
         @Nonnull
         final int hash;
+        private final IAEItemStack[] cachedOutputs;
+        private final IAEItemStack[] cachedInputs;
+        private final ItemStack pattern;
 
         @Override
         public boolean equals(Object obj) {
@@ -403,15 +404,9 @@ public class ProgrammingCircuitProvider extends MTEHatch implements IAddUIWidget
             if (o.stackSize <= 0) throw new IllegalArgumentException("invalid stackSize");
             hash = AEItemStack.create(out)
                 .hashCode() ^ 0x1234abcd;
-            /*
-             * if(out ==null){ Thread.dumpStack();
-             * System.exit(0);}
-             */
-        }
-
-        @Override
-        public ItemStack getPattern() {
-            return Optional.of(new ItemStack(MyMod.fakepattern))
+            this.cachedOutputs = new IAEItemStack[] { AEApi.instance().storage().createItemStack(out) };
+            this.cachedInputs = new IAEItemStack[] { AEApi.instance().storage().createItemStack(new ItemStack(Items.apple, 0)) };
+            this.pattern = Optional.of(new ItemStack(MyMod.fakepattern))
                 .map(s -> {
 
                     s.stackTagCompound = (NBTTagCompound) out.writeToNBT(new NBTTagCompound())
@@ -420,6 +415,15 @@ public class ProgrammingCircuitProvider extends MTEHatch implements IAddUIWidget
                     return s;
                 })
                 .get();
+            /*
+             * if(out ==null){ Thread.dumpStack();
+             * System.exit(0);}
+             */
+        }
+
+        @Override
+        public ItemStack getPattern() {
+            return pattern;
 
         }
 
@@ -442,28 +446,24 @@ public class ProgrammingCircuitProvider extends MTEHatch implements IAddUIWidget
         @Override
         public IAEItemStack[] getInputs() {
 
-            return new IAEItemStack[] { AEApi.instance()
-                .storage()
-                .createItemStack(new ItemStack(Items.apple, 0)) };
+            return cachedInputs;
         }
 
         @Override
         public IAEItemStack[] getCondensedInputs() {
-            return getInputs();
+            return cachedInputs;
         }
 
         @Override
         public IAEItemStack[] getCondensedOutputs() {
 
-            return new IAEItemStack[] { AEApi.instance()
-                .storage()
-                .createItemStack(out) };
+            return cachedOutputs;
         }
 
         @Override
         public IAEItemStack[] getOutputs() {
 
-            return getCondensedOutputs();
+            return cachedOutputs;
         }
 
         @Override
@@ -758,6 +758,8 @@ public class ProgrammingCircuitProvider extends MTEHatch implements IAddUIWidget
         customName = name;
 
     }
+
+
 
     @Override
     public boolean shouldDropItemAt(int index) {

--- a/src/main/java/reobf/proghatches/item/ItemProgrammingCircuit.java
+++ b/src/main/java/reobf/proghatches/item/ItemProgrammingCircuit.java
@@ -1,6 +1,7 @@
 package reobf.proghatches.item;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 
@@ -152,6 +153,8 @@ public class ItemProgrammingCircuit extends Item {
         return wrap(is, i, false);
     }
 
+    private static final HashMap<Item, String> nameCache = new HashMap<>();
+
     public static ItemStack wrap(ItemStack is, int i, boolean legacy) {
 
         ItemStack iss = new ItemStack(MyMod.progcircuit, i);
@@ -162,7 +165,10 @@ public class ItemProgrammingCircuit extends Item {
             NBTTagCompound tag = (NBTTagCompound) is.writeToNBT(new NBTTagCompound())
                 .copy();
 
-            if (!legacy) tag.setString("string_id", Item.itemRegistry.getNameForObject(is.getItem()));
+            if (!legacy) {
+                String name = nameCache.computeIfAbsent(is.getItem(), Item.itemRegistry::getNameForObject);
+                tag.setString("string_id", name);
+            }
             if (tag.hasKey("string_id")) tag.removeTag("id");
             iss.stackTagCompound.setTag("targetCircuit", tag);
 
@@ -171,6 +177,8 @@ public class ItemProgrammingCircuit extends Item {
 
     }
 
+    private static final HashMap<String, Integer> idCache = new HashMap<>();
+
     public static ItemStack parse(NBTTagCompound tag) {
 
         String s = tag.getString("string_id");
@@ -178,7 +186,8 @@ public class ItemProgrammingCircuit extends Item {
         if (s.isEmpty() == false) {
             // if string id is present, replace the number id
             tag = (NBTTagCompound) tag.copy();// note to self: copy it before modifying it!!!
-            tag.setInteger("id", Item.itemRegistry.getIDForObject(Item.itemRegistry.getObject(s)));
+            int id = idCache.computeIfAbsent(s, k -> Item.itemRegistry.getIDForObject(Item.itemRegistry.getObject(k)));
+            tag.setInteger("id", id);
         }
 
         return ItemStack.loadItemStackFromNBT(tag);


### PR DESCRIPTION
大规模的AE2合成请求，特别是涉及到编程电路的合成，会导致严重的服务器卡顿甚至完全冻结。性能分析（Profiling）显示，瓶颈主要在于`pushPattern`和样板详情方法中，过度且重复地创建`AEItemStack`对象以及随之而来的昂贵的NBT比较操作。

本次提交通过以下几项关键优化来解决此问题：

1.  **缓存样板详情**: 在`CircuitProviderPatternDetial`内部类中，`getOutputs()`、`getInputs()`和`getPattern()`的结果在对象实例化时被一次性计算并缓存到`final`字段中。这避免了在合成计算的每个环节中都重复创建新的`IAEItemStack`数组和样板`ItemStack`。

2.  **优化`pushPattern`方法**: `ProgrammingCircuitProvider`中的`pushPattern`方法被重构，现在它直接利用样板详情中已缓存的`IAEItemStack`输出，彻底消除了一个多余且极其耗费性能的`AEItemStack.create()`调用。

3.  **缓存注册表查找**: 在`ItemProgrammingCircuit`中，为物品到其字符串ID以及字符串ID到其数字ID的转换添加了静态缓存。这减少了在打包和解析编程电路时与游戏注册表交互的开销。

这些改动极大地减少了合成计算过程中的对象创建和CPU负载，从而恢复了服务器在处理大规模自动化合成时的性能和响应能力。