### PR TITLE
Explicitly loading MixinMEBusOverrideF

### DIFF
--- a/src/main/java/reobf/proghatches/main/mixin/MixinPlugin.java
+++ b/src/main/java/reobf/proghatches/main/mixin/MixinPlugin.java
@@ -38,10 +38,10 @@ import cpw.mods.fml.relauncher.FMLLaunchHandler;
 
 public class MixinPlugin implements IMixinConfigPlugin {
 static{
-	
-	
-	
-      
+
+
+
+
 }
     public MixinPlugin() {
         System.out.println("xx");
@@ -193,6 +193,7 @@ public static boolean loaded;
         retLate.add("part2.MixinMultiPattern");
         // retLate.add("part2.MixinSplitDetect");
         retLate.add("part2.MixinMEBusOverride");
+        retLate.add("part2.MixinMEBusOverrideF");
         retLate.add("part2.MixinCraftingCondender");
         //retLate.add("part2.MixinVoidingHatch");
         retLate.add("part2.MixinCraftingV2");
@@ -217,31 +218,31 @@ public static boolean loaded;
 
             if (!"true".equals(pp.get("noPatternEncodingMixin"))) {
                 // if(ff)retLate.add("MixinPatternEncodingCiruitSpecialTreatment");
-            	
+
             	//  wo/ fluid
-                retLate.add("MixinPatternEncodingCiruitSpecialTreatment2"); 
+                retLate.add("MixinPatternEncodingCiruitSpecialTreatment2");
                 //  with fluid
                //legacy
                 retLate.add("part2.MixinPatternEncodingCiruitSpecialTreatmentNeo");
-                
-                
+
+
             }
             retLate.add("part2.MixinGTCopiedBlockTextureRender");
-        } ; 
+        } ;
         //retLate.add("part2.MixinFixSolidfier");
         retLate.add("part2.MixinOptimize");
         retLate.add("part2.MixinProcessLogicReset");
         retLate.add("cpu.MixinCache");
         retLate.add("cpu.MixinCPU");
         retLate.add("part2.MixinTerminalCtrlInvert");
-        
+
         return ret;
 
     }
 
     @Override
     public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
-       
+
 
     }
 
@@ -250,9 +251,9 @@ public static boolean loaded;
 
     }
 
-    
+
 
     public static final Logger LOG = LogManager.getLogger("PHMixin");
-    
- 
+
+
 }

--- a/src/main/resources/mixins.programmablehatches.late.json
+++ b/src/main/resources/mixins.programmablehatches.late.json
@@ -4,9 +4,7 @@
   "refmap": "mixins.programmablehatches.refmap.json",
   "target": "@env(DEFAULT)",
   "compatibilityLevel": "JAVA_8",
-  "mixins": [
-    "part2.MixinMEBusOverrideF"
-  ],
+  "mixins": [],
   "client": [],
   "server": []
 }

--- a/src/main/resources/mixins.programmablehatches.late.json
+++ b/src/main/resources/mixins.programmablehatches.late.json
@@ -4,7 +4,9 @@
   "refmap": "mixins.programmablehatches.refmap.json",
   "target": "@env(DEFAULT)",
   "compatibilityLevel": "JAVA_8",
-  "mixins": [],
+  "mixins": [
+    "part2.MixinMEBusOverrideF"
+  ],
   "client": [],
   "server": []
 }


### PR DESCRIPTION
The hatch override mixin was not loaded, preventing [`updateInformationSlot()`](https://github.com/reobf/Programmable-Hatches-Mod/blob/290-daily-latest/src/main/java/reobf/proghatches/main/mixin/mixins/part2/MixinMEBusOverrideF.java#L59-L74) redirect from being applied by [`MixinMEBusOverrideF`](https://github.com/reobf/Programmable-Hatches-Mod/blob/290-daily-latest/src/main/java/reobf/proghatches/main/mixin/mixins/part2/MixinMEBusOverrideF.java). This caused the Restricted Stocking Input Hatch to provide the wrong pull amount in the UI and to the machine.

I observed that `MixinMEBusOverrideF` was not loaded during startup, while `MixinMEBusOverride` was.
```
[Client thread/INFO] [GTNHMixins]: Loading [mixins.programmablehatches.late.json] part2.MixinMEBusOverride
```
Since this mixin loaded, the Restricted Stocking Input Bus did not have this bug.

This is an example of this bug, along with a Dissolution Tank recipe at the start of the Prismarine line.
The hatch is instructed to pull exactly 6kL of fluid. The hatch pulled all 2.1GL instead, causing the Dissolution Tank recipe fail due to wrong fluid ratio.
Before:
<img width="2560" height="1494" alt="2026-07-31_14 11 07" src="https://github.com/user-attachments/assets/140f3766-347d-4acd-b404-f2cf0d2eceb0" />
<img width="2560" height="1494" alt="2026-07-31_14 11 40" src="https://github.com/user-attachments/assets/f66126c2-f9f4-48a5-b6e8-1c80b341af3a" />

After:
<img width="2560" height="1494" alt="2026-07-31_14 14 17" src="https://github.com/user-attachments/assets/3b0b5158-b61a-42d6-9db2-bc1120a6e8ba" />
<img width="2560" height="1494" alt="2026-07-31_14 14 27" src="https://github.com/user-attachments/assets/08d8dceb-fcc0-424e-8a5d-a90d4e983aed" />

## Note
I wasn't able to determine why `MixinMEBusOverrideF` wasn't loaded, so this PR registers it explicitly.