### PR TITLE
Fix ArrayStoreException in RequestTunnel.getTankInfo

### DIFF
--- a/src/main/java/reobf/proghatches/ae/part2/RequestTunnel.java
+++ b/src/main/java/reobf/proghatches/ae/part2/RequestTunnel.java
@@ -734,7 +734,7 @@ boolean returnAll=true;
     public FluidTankInfo[] getTankInfo(ForgeDirection from) {
 
         return cacheFR.stream()
-            .map(s -> new FluidTank(s, 1))
+            .map(s -> new FluidTankInfo(s, 1))
             .toArray(FluidTankInfo[]::new);
     }
 


### PR DESCRIPTION
## Fix

`RequestTunnel.getTankInfo` maps `cacheFR` (a `List<FluidStack>`) to `FluidTank` but stores the result into a `FluidTankInfo[]`:

    .map(s -> new FluidTank(s, 1)).toArray(FluidTankInfo[]::new);

In GTNH Forge 1.7.10-10.13.4.1614, `FluidTank implements IFluidTank` and is NOT a subtype of the `final` class `FluidTankInfo`, so the store throws `ArrayStoreException` whenever `cacheFR` is non-empty.

## Trigger

Opening the AE2 Interface Terminal (or ae2thing Wireless Dual Interface Terminal) while a Request Tunnel part is on the network. The terminal's `ContainerInterfaceTerminal.updateList` -> `DualityInterface.getCrafterIcon` -> `InventoryAdaptor.getAdaptor` path probes the tile's `getTankInfo` every tick, crashing the server with "Ticking entity" when `cacheFR` is non-empty.

## Change

Map to `FluidTankInfo` instead (equivalent semantics: fluid = `s`, capacity = 1):

    .map(s -> new FluidTankInfo(s, 1)).toArray(FluidTankInfo[]::new);

Locally verified (hot-patched the class and confirmed no crash).